### PR TITLE
Ajouté l'enum gender et mis à jour fixture

### DIFF
--- a/backend/migrations/Version20260310092106.php
+++ b/backend/migrations/Version20260310092106.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260310092106 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE animals CHANGE gender gender INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE animals CHANGE gender gender TINYINT NOT NULL');
+    }
+}

--- a/backend/src/Controller/AnimalsController.php
+++ b/backend/src/Controller/AnimalsController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\Animals;
 use App\Entity\Enclosure;
 use App\Entity\Species;
+use App\Enum\Gender;
 use App\Repository\AnimalsRepository;
 use App\Repository\EnclosureRepository;
 use App\Repository\SpeciesRepository;
@@ -158,11 +159,12 @@ class AnimalsController
         $age = $payload['age'] ?? null;
         $speciesId = $payload['speciesId'] ?? null;
         $enclosureId = $payload['enclosureId'] ?? null;
+        $genderEnum = is_int($gender) ? Gender::tryFrom($gender) : null;
 
         if (
             !is_string($name)
             || trim($name) === ''
-            || !is_bool($gender)
+            || $genderEnum === null
             || !is_int($weight)
             || !is_int($size)
             || !is_int($age)
@@ -199,7 +201,7 @@ class AnimalsController
 
         $animals
             ->setName(trim($name))
-            ->setGender($gender)
+            ->setGender($genderEnum)
             ->setWeight($weight)
             ->setSize($size)
             ->setAge($age)
@@ -218,7 +220,7 @@ class AnimalsController
             'id' => $animals->getId(),
             'uuid' => $animals->getUuid()?->toRfc4122(),
             'name' => $animals->getName(),
-            'gender' => $animals->isGender(),
+            'gender' => $animals->getGender(),
             'weight' => $animals->getWeight(),
             'size' => $animals->getSize(),
             'age' => $animals->getAge(),

--- a/backend/src/DataFixtures/AppFixtures.php
+++ b/backend/src/DataFixtures/AppFixtures.php
@@ -9,6 +9,7 @@ use App\Entity\Species;
 use App\Entity\User;
 use App\Entity\UserProfile;
 use App\Enum\ClearanceLevel;
+use App\Enum\Gender;
 use App\Enum\SpeciesDiet;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
@@ -93,13 +94,13 @@ class AppFixtures extends Fixture
         }
 
         $animalsData = [
-            ['name' => 'Rexy', 'gender' => true, 'weight' => 7000, 'size' => 13, 'age' => 12, 'species' => 'Tyrannosaurus rex', 'enclosure' => 'Carnivore Zone Alpha'],
-            ['name' => 'Stormclaw', 'gender' => false, 'weight' => 90, 'size' => 2, 'age' => 6, 'species' => 'Velociraptor', 'enclosure' => 'Raptor Compound'],
-            ['name' => 'AquaFang', 'gender' => true, 'weight' => 8200, 'size' => 15, 'age' => 14, 'species' => 'Spinosaurus', 'enclosure' => 'Carnivore Zone Alpha'],
-            ['name' => 'Trike', 'gender' => false, 'weight' => 6000, 'size' => 9, 'age' => 10, 'species' => 'Triceratops', 'enclosure' => 'Waterfront Paddock'],
-            ['name' => 'Spike', 'gender' => true, 'weight' => 5000, 'size' => 8, 'age' => 11, 'species' => 'Stegosaurus', 'enclosure' => 'Herbivore Plains'],
-            ['name' => 'Tank', 'gender' => false, 'weight' => 7000, 'size' => 7, 'age' => 13, 'species' => 'Ankylosaurus', 'enclosure' => 'Omnivore Habitat'],
-            ['name' => 'Swiftfoot', 'gender' => true, 'weight' => 450, 'size' => 4, 'age' => 5, 'species' => 'Gallimimus', 'enclosure' => 'Herbivore Plains'],
+            ['name' => 'Rexy', 'gender' => Gender::FEMALE, 'weight' => 7000, 'size' => 13, 'age' => 12, 'species' => 'Tyrannosaurus rex', 'enclosure' => 'Carnivore Zone Alpha'],
+            ['name' => 'Stormclaw', 'gender' => Gender::MALE, 'weight' => 90, 'size' => 2, 'age' => 6, 'species' => 'Velociraptor', 'enclosure' => 'Raptor Compound'],
+            ['name' => 'AquaFang', 'gender' => Gender::FEMALE, 'weight' => 8200, 'size' => 15, 'age' => 14, 'species' => 'Spinosaurus', 'enclosure' => 'Carnivore Zone Alpha'],
+            ['name' => 'Trike', 'gender' => Gender::MALE, 'weight' => 6000, 'size' => 9, 'age' => 10, 'species' => 'Triceratops', 'enclosure' => 'Waterfront Paddock'],
+            ['name' => 'Spike', 'gender' => Gender::FEMALE, 'weight' => 5000, 'size' => 8, 'age' => 11, 'species' => 'Stegosaurus', 'enclosure' => 'Herbivore Plains'],
+            ['name' => 'Tank', 'gender' => Gender::MALE, 'weight' => 7000, 'size' => 7, 'age' => 13, 'species' => 'Ankylosaurus', 'enclosure' => 'Omnivore Habitat'],
+            ['name' => 'Swiftfoot', 'gender' => Gender::FEMALE, 'weight' => 450, 'size' => 4, 'age' => 5, 'species' => 'Gallimimus', 'enclosure' => 'Herbivore Plains'],
         ];
 
         foreach ($animalsData as $data) {

--- a/backend/src/Entity/Animals.php
+++ b/backend/src/Entity/Animals.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Enum\Gender;
 use App\Repository\AnimalsRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Types\UuidType;
@@ -25,8 +26,8 @@ class Animals
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
-    #[ORM\Column]
-    private ?bool $gender = null;
+    #[ORM\Column(enumType: Gender::class)]
+    private ?Gender $gender = null;
 
     #[ORM\Column]
     private ?int $weight = null;
@@ -87,12 +88,12 @@ class Animals
         return $this;
     }
 
-    public function isGender(): ?bool
+    public function getGender(): ?Gender
     {
         return $this->gender;
     }
 
-    public function setGender(bool $gender): static
+    public function setGender(Gender $gender): static
     {
         $this->gender = $gender;
 

--- a/backend/src/Enum/Gender.php
+++ b/backend/src/Enum/Gender.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum Gender: int
+{
+    case MALE = 0;
+    case FEMALE = 1;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -78,7 +78,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2008,7 +2007,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2019,7 +2017,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2080,7 +2077,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -2332,7 +2328,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2490,7 +2485,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2667,8 +2661,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -2859,7 +2852,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,7 +3817,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3888,7 +3879,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3898,7 +3888,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3911,7 +3900,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
       "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4094,7 +4082,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -4251,7 +4238,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4346,7 +4332,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4467,7 +4452,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Modifications
- Remplacement du champ `gender` (booléen) par une enum `Gender`.
- Mise à jour des fixtures pour utiliser cette nouvelle enum.

## Pourquoi
Le genre était auparavant représenté par un booléen, ce qui limitait la lisibilité et l’évolutivité.  
L'utilisation d'une enum permet de rendre les valeurs plus explicites et plus faciles à maintenir.

## Impact
- Les fixtures ont été adaptées pour utiliser l'enum `Gender`.
- Pas d’impact fonctionnel attendu en dehors de l’adaptation des données.