### PR TITLE
Add ProfileController and update AppFixtures for user roles

### DIFF
--- a/backend/src/Controller/ProfileController.php
+++ b/backend/src/Controller/ProfileController.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Entity\UserProfile;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ProfileController
+{
+    public function __construct(
+        private readonly Security $security,
+    ) {}
+
+    #[Route('/api/profile/{id}', name: 'profile_get', methods: ['GET'])]
+    public function getOne(?User $user): JsonResponse
+    {
+        if ($user === null) {
+            return new JsonResponse([
+                'error' => 'Profile not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $authenticatedUser = $this->getAuthenticatedUser();
+        if (!$authenticatedUser instanceof User) {
+            return new JsonResponse([
+                'error' => 'Unauthorized.',
+            ], JsonResponse::HTTP_UNAUTHORIZED);
+        }
+
+        if (!$this->canAccessProfile($authenticatedUser, $user)) {
+            return new JsonResponse([
+                'error' => 'Access denied.',
+            ], JsonResponse::HTTP_FORBIDDEN);
+        }
+
+        $userProfile = $user->getUserProfile();
+        if (!$userProfile instanceof UserProfile) {
+            return new JsonResponse([
+                'error' => 'Profile not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        return new JsonResponse($this->toResponse($user, $userProfile));
+    }
+
+    #[Route('/api/profile/{id}', name: 'profile_update', methods: ['PUT'])]
+    public function update(?User $user, Request $request, EntityManagerInterface $entityManager): JsonResponse
+    {
+        if ($user === null) {
+            return new JsonResponse([
+                'error' => 'Profile not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $authenticatedUser = $this->getAuthenticatedUser();
+        if (!$authenticatedUser instanceof User) {
+            return new JsonResponse([
+                'error' => 'Unauthorized.',
+            ], JsonResponse::HTTP_UNAUTHORIZED);
+        }
+
+        if (!$this->canAccessProfile($authenticatedUser, $user)) {
+            return new JsonResponse([
+                'error' => 'Access denied.',
+            ], JsonResponse::HTTP_FORBIDDEN);
+        }
+
+        $userProfile = $user->getUserProfile();
+        if (!$userProfile instanceof UserProfile) {
+            return new JsonResponse([
+                'error' => 'Profile not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        try {
+            /** @var mixed $payload */
+            $payload = $request->toArray();
+        } catch (\JsonException) {
+            return new JsonResponse([
+                'error' => 'Invalid JSON body.',
+            ], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        if (!is_array($payload)) {
+            return new JsonResponse([
+                'error' => 'Invalid JSON body.',
+            ], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $allowedKeys = ['firstName', 'lastName', 'telephone'];
+        foreach (array_keys($payload) as $key) {
+            if (!in_array($key, $allowedKeys, true)) {
+                return new JsonResponse([
+                    'error' => 'Invalid JSON body.',
+                ], JsonResponse::HTTP_BAD_REQUEST);
+            }
+        }
+
+        $firstName = $payload['firstName'] ?? null;
+        $lastName = $payload['lastName'] ?? null;
+        $telephone = $payload['telephone'] ?? null;
+
+        if (
+            !is_string($firstName)
+            || trim($firstName) === ''
+            || !is_string($lastName)
+            || trim($lastName) === ''
+            || !(is_string($telephone) || $telephone === null)
+        ) {
+            return new JsonResponse([
+                'error' => 'Fields firstName and lastName are required.',
+            ], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $userProfile
+            ->setFirstName(trim($firstName))
+            ->setLastName(trim($lastName))
+            ->setTelephone($telephone === null ? null : trim($telephone));
+
+        $entityManager->flush();
+
+        return new JsonResponse($this->toResponse($user, $userProfile));
+    }
+
+    private function getAuthenticatedUser(): ?User
+    {
+        $user = $this->security->getUser();
+
+        return $user instanceof User ? $user : null;
+    }
+
+    private function canAccessProfile(User $authenticatedUser, User $targetUser): bool
+    {
+        return $authenticatedUser->getId() === $targetUser->getId() || $this->security->isGranted('ROLE_ADMIN');
+    }
+
+    private function toResponse(User $user, UserProfile $userProfile): array
+    {
+        return [
+            'userId' => $user->getId(),
+            'email' => $user->getEmail(),
+            'firstName' => $userProfile->getFirstName(),
+            'lastName' => $userProfile->getLastName(),
+            'telephone' => $userProfile->getTelephone(),
+        ];
+    }
+}

--- a/backend/src/DataFixtures/AppFixtures.php
+++ b/backend/src/DataFixtures/AppFixtures.php
@@ -25,7 +25,7 @@ class AppFixtures extends Fixture
     {
         $user = new User();
         $user->setEmail('test@example.com');
-        $user->setRoles(['ROLE_USER']);
+        $user->setRoles(['ROLE_USER', 'ROLE_ADMIN']);
         $user->setPassword(
             $this->passwordHasher->hashPassword($user, 'test1234')
         );
@@ -133,7 +133,7 @@ class AppFixtures extends Fixture
 
         $usersData = [
             ['email' => 'user1@example.com', 'firstName' => 'Alice', 'lastName' => 'Martin', 'telephone' => '+33100000002', 'job' => 'Ranger', 'clearance' => ClearanceLevel::MODERATE, 'dateOfBirth' => '1988-02-03'],
-            ['email' => 'user2@example.com', 'firstName' => 'Bruno', 'lastName' => 'Lefevre', 'telephone' => '+33100000003', 'job' => 'Security Officer', 'clearance' => ClearanceLevel::CRITICAL, 'dateOfBirth' => '1985-06-21'],
+            ['email' => 'user2@example.com', 'firstName' => 'Bruno', 'lastName' => 'Lefevre', 'telephone' => '+33100000003', 'job' => 'Security Officer', 'clearance' => ClearanceLevel::CRITICAL, 'dateOfBirth' => '1985-06-21', 'roles' => ['ROLE_ADMIN']],
             ['email' => 'user3@example.com', 'firstName' => 'Claire', 'lastName' => 'Dupont', 'telephone' => '+33100000004', 'job' => 'Biologist', 'clearance' => ClearanceLevel::HIGH, 'dateOfBirth' => '1992-11-10'],
             ['email' => 'user4@example.com', 'firstName' => 'David', 'lastName' => 'Moreau', 'telephone' => '+33100000005', 'job' => 'Veterinarian', 'clearance' => ClearanceLevel::HIGH, 'dateOfBirth' => '1991-09-05'],
             ['email' => 'user5@example.com', 'firstName' => 'Emma', 'lastName' => 'Petit', 'telephone' => '+33100000006', 'job' => 'Animal Caretaker', 'clearance' => ClearanceLevel::LOW, 'dateOfBirth' => '1995-04-17'],
@@ -148,7 +148,7 @@ class AppFixtures extends Fixture
             $seededUser = new User();
             $seededUser
                 ->setEmail($data['email'])
-                ->setRoles(['ROLE_USER'])
+                ->setRoles($data['roles'] ?? ['ROLE_USER'])
                 ->setPassword(
                     $this->passwordHasher->hashPassword($seededUser, 'test1234')
                 );


### PR DESCRIPTION
This pull request introduces a new `ProfileController` for handling user profile retrieval and updates, including robust access control and input validation. Additionally, it updates the user data fixtures to better support role management, including assigning admin roles to specific users.

New profile management features:

* Added `ProfileController` with endpoints for retrieving and updating user profiles, including access checks and detailed input validation. (`backend/src/Controller/ProfileController.php`)

Fixture improvements for role management:

* Updated the main test user to have both `ROLE_USER` and `ROLE_ADMIN` for broader testing coverage. (`backend/src/DataFixtures/AppFixtures.php`)
* Modified fixture data to allow specifying roles per user, and assigned `ROLE_ADMIN` to user2 for admin scenario testing. (`backend/src/DataFixtures/AppFixtures.php`)
* Changed user creation logic to use roles from fixture data if provided, otherwise default to `ROLE_USER`. (`backend/src/DataFixtures/AppFixtures.php`)